### PR TITLE
UserContext를 받아오는 문제가 있었음.

### DIFF
--- a/src/components/providers/UserContextProvider.tsx
+++ b/src/components/providers/UserContextProvider.tsx
@@ -21,11 +21,9 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   const [forceReload, setForceReload] = useState<string>('');
   const navigate = useNavigate();
   const { data: userContext, isLoading } = useUserContextQuery(forceReload);
-  const [childrenReal, setChildrenReal] = useState<ReactNode>(<div>로딩중</div>);
   
 
   useEffect(() => {
-    console.log('userContext', userContext);
     if (!userContext || isLoading) {
       return;
     }
@@ -35,13 +33,10 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
       navigate('/onBoarding');
       return;
     }
-    else{
-      setChildrenReal(children);
-    }
   }, [userContext]);
 
-  if (!userContext) {
-    return childrenReal;
+  if (!userContext || userContext!.channelPermissions.length === 0) {
+    return <div>로딩중</div>;
   }
 
   return (
@@ -51,7 +46,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         setForceReload,
       }}
     >
-      {childrenReal}
+      {children}
     </UsrContext.Provider>
   );
 }


### PR DESCRIPTION
userContext의 조건을 확인하는 구문이 useEffect안에 있어서 navigate(onBoarding)으로 이동하기 전에 child를 마운팅하여, 에러가 발생했음. 순서는 state 및 const 생성 -> return -> useEffect 구문 실행. 따라서 상태를 확인하기 전에 마운팅될 수 있는 state값을 지정해야했음. 이를 childerReal로 지정. childrenReal은 null값으로 지정되어있으나, userContext값이 변경됨에 따라 상태를 확인하고, 문제가 없으면 children을 담을 수 있도록 함.