### PR TITLE
[Fix] 온보딩에서 채널을 생성해도 다시 온보딩 페이지로 이동하는 문제 해결

### DIFF
--- a/src/Pages/CreateChannel.tsx
+++ b/src/Pages/CreateChannel.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 
 import { channelApi, userApi } from '../api';
 import { LocalStorageUtils } from '../utils/LocalStorageUtils.ts';
+import { useUserContextQuery } from '../api/queries.tsx';
+import { useState } from 'react';
 
 type CreateChannelType = {
   channelName: string;
@@ -12,7 +14,6 @@ type CreateChannelType = {
 
 export function CreateChannel() {
   const navigate = useNavigate();
-
   const onSubmit = (value: CreateChannelType) => {
     (async () => {
       const response = await channelApi.createChannelAsync({
@@ -27,7 +28,7 @@ export function CreateChannel() {
         LocalStorageUtils.setSelectedChannelId(
           userResponse.data.channelPermissionList[0].channelId,
         );
-        navigate('/home');
+        navigate('/home', {state: {userContextReloadKey: 'true'}});
       }
     })();
   };

--- a/src/Pages/Home.tsx
+++ b/src/Pages/Home.tsx
@@ -11,7 +11,7 @@ import {
 } from 'antd';
 import Meta from 'antd/es/card/Meta';
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { sketchApi } from '../api';
 import { MainLayout } from '../components/MainLayout.tsx';
@@ -24,8 +24,11 @@ type CreateSketchType = {
 };
 
 export function Home() {
+  const location = useLocation();
+  const state = {...location.state};
+  const userContextReloadKey = state.userContextReloadKey;
   return (
-    <MainLayout pageKey={'sketch-list'}>
+    <MainLayout pageKey={'sketch-list'} userContextReloadKey={userContextReloadKey}>
       <SketchListView />
     </MainLayout>
   );

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -22,15 +22,17 @@ export function MainLayout({
   children,
   selectorRef,
   pageKey,
+  userContextReloadKey,
 }: {
   children: ReactNode;
   selectorRef?: React.Ref<HTMLDivElement> | undefined;
   pageKey: PageKey;
+  userContextReloadKey?: string,
 }) {
   return (
     <ErrorHandlerProvider>
       <AuthProvider>
-        <UserContextProvider>
+        <UserContextProvider isReload = {userContextReloadKey}>
           <ChannelNavigationProvider>
             <InnerLayout pageKey={pageKey} selectorRef={selectorRef}>
               {children}

--- a/src/components/providers/UserContextProvider.tsx
+++ b/src/components/providers/UserContextProvider.tsx
@@ -17,11 +17,11 @@ type UserContextValue = {
   setForceReload: (reloadKey: string) => void;
 };
 
-export function UserContextProvider({ children }: { children: ReactNode }) {
-  const [forceReload, setForceReload] = useState<string>('');
+export function UserContextProvider({ children, isReload}: { children: ReactNode, isReload?:string }) {
+  const [forceReload, setForceReload] = useState<string>(isReload || '');
   const navigate = useNavigate();
   const { data: userContext, isLoading } = useUserContextQuery(forceReload);
-
+  
   useEffect(() => {
     if (!userContext || isLoading) {
       return;


### PR DESCRIPTION
home에서 userContext가 refetch되기 전에 previousData를 참고하여 이전 데이터를 참고하여, onBoarding페이지로 이동하는 문제가 있었음.
이를 해결하기 위해 UserContextProvider에 refetch가 필요한 경우를 인자로 넘겨줌.

- UserContextProvide에서 reload를 위한 설정이 없어, 페이지를 통해 전달해줄 수 있도록 함.
- previousData를 사용하지 않으면, 사용자의 체감 로딩 시간이 늘어나기 때문에, previousData를 사용하되, 채널을 생성하고 home으로 이동할 때에는 refetch 되도록 함.
- 다른 해결 방안
1. UserContextProvider에서 use..('true)를 통해 매번 데이터가 refetch되도록 함.
2. 전역변수 지정(페이지로 인자 전달을 하지 않을 수 있음.)